### PR TITLE
Fix navigation links and API base URL

### DIFF
--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 
 const Header: React.FC = () => {
@@ -12,13 +13,18 @@ const Header: React.FC = () => {
           <span className="font-bold text-xl">Sistema de Patentes</span>
         </div>
         <div className="flex space-x-6 items-center">
-          <a href="#" className="hover:text-blue-200 font-medium">
-            <i className="fas fa-home mr-1"></i> Inicio
-          </a>
+          <Link to="/dashboard" className="hover:text-blue-200 font-medium">
+            <i className="fas fa-home mr-1"></i> Dashboard
+          </Link>
+          {user && (
+            <Link to="/history" className="hover:text-blue-200 font-medium">
+              <i className="fas fa-history mr-1"></i> Historial
+            </Link>
+          )}
           {user?.role === 'admin' && (
-            <a href="#" className="hover:text-blue-200 font-medium">
+            <Link to="/admin" className="hover:text-blue-200 font-medium">
               <i className="fas fa-cog mr-1"></i> Administración
-            </a>
+            </Link>
           )}
           <div className="flex items-center space-x-2 bg-blue-700 px-3 py-1 rounded-full">
             <i className="fas fa-user-circle"></i>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
 const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- replace header anchor tags with React Router links for dashboard, history, and admin navigation
- use relative API base URL so frontend and backend communicate consistently

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run build` (frontend) *(fails: vite Permission denied)*
- `npm test` (backend) *(fails: no test specified)*
- `npm run build` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_68b84664539883248836f54a5b70fb15