### PR TITLE
Add plate stats endpoint and show counts in admin dashboard

### DIFF
--- a/backend/src/controllers/plateController.ts
+++ b/backend/src/controllers/plateController.ts
@@ -40,6 +40,21 @@ export const getPlates = async (req: Request, res: Response): Promise<void> => {
   }
 };
 
+export const getPlateStats = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const stats = await query(
+      `SELECT COUNT(*) AS total,
+              SUM(CASE WHEN is_active = TRUE THEN 1 ELSE 0 END) AS active,
+              SUM(CASE WHEN is_active = FALSE THEN 1 ELSE 0 END) AS inactive
+       FROM plates`
+    );
+    res.json(stats[0]);
+  } catch (error) {
+    logger.error('Get plate stats error:', error);
+    res.status(500).json({ total: 0, active: 0, inactive: 0 });
+  }
+};
+
 export const getPlate = async (req: Request, res: Response): Promise<void> => {
   try {
     const plates = await query(

--- a/backend/src/routes/plates.ts
+++ b/backend/src/routes/plates.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { body } from 'express-validator';
-import { getPlates, getPlate, createPlate, updatePlate, deletePlate } from '../controllers/plateController';
+import { getPlates, getPlate, createPlate, updatePlate, deletePlate, getPlateStats } from '../controllers/plateController';
 import { authenticate, authorize } from '../middleware/auth';
 import { handleValidationErrors } from '../middleware/validation';
 
@@ -10,6 +10,7 @@ const router = express.Router();
 router.use(authenticate);
 
 router.get('/', getPlates);
+router.get('/stats', authorize('admin'), getPlateStats);
 router.get('/:id', getPlate);
 
 // Only admins can modify plates
@@ -18,7 +19,7 @@ router.post('/', [
   body('plateNumber').notEmpty().withMessage('Plate number is required'),
   body('owner').notEmpty().withMessage('Owner is required'),
   body('vehicleType').notEmpty().withMessage('Vehicle type is required'),
-  body('model').notEmpty().withMessage('Model is required'),
+  body('vehicleModel').notEmpty().withMessage('Vehicle model is required'),
   body('color').notEmpty().withMessage('Color is required'),
   handleValidationErrors
 ], createPlate);
@@ -27,7 +28,7 @@ router.put('/:id', [
   authorize('admin'),
   body('owner').notEmpty().withMessage('Owner is required'),
   body('vehicleType').notEmpty().withMessage('Vehicle type is required'),
-  body('model').notEmpty().withMessage('Model is required'),
+  body('vehicleModel').notEmpty().withMessage('Vehicle model is required'),
   body('color').notEmpty().withMessage('Color is required'),
   handleValidationErrors
 ], updatePlate);

--- a/frontend/src/components/plates/PlateList.tsx
+++ b/frontend/src/components/plates/PlateList.tsx
@@ -91,7 +91,13 @@ const PlateList: React.FC = () => {
     try {
       const plate = plates.find(p => p.id === id);
       if (plate) {
-        await updatePlate(id, { ...plate, isActive });
+        await updatePlate(id, {
+          owner: plate.owner,
+          vehicleType: plate.vehicle_type,
+          vehicleModel: plate.vehicle_model,
+          color: plate.color,
+          isActive,
+        });
         await fetchPlates();
       }
     } catch (err: any) {

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PlateList from '../components/plates/PlateList';
 import PlateForm from '../components/plates/PlateForm';
-import { registerPlate } from '../services/plateService';
+import { registerPlate, getPlateStats } from '../services/plateService';
 import { useAuth } from '../context/AuthContext';
 import Notification from '../components/common/Notification';
 
@@ -17,6 +17,19 @@ const Admin: React.FC = () => {
     message: '',
     isVisible: false
   });
+  const [stats, setStats] = useState({ total: 0, active: 0, inactive: 0 });
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const data = await getPlateStats();
+        setStats(data);
+      } catch (error) {
+        console.error('Error fetching stats', error);
+      }
+    };
+    fetchStats();
+  }, []);
 
   const showNotification = (type: 'success' | 'error' | 'warning' | 'info', message: string) => {
     setNotification({ type, message, isVisible: true });
@@ -87,7 +100,7 @@ const Admin: React.FC = () => {
               <i className="fas fa-car text-blue-600 text-xl"></i>
             </div>
             <div>
-              <h3 className="text-2xl font-bold text-gray-800">1,248</h3>
+              <h3 className="text-2xl font-bold text-gray-800">{stats.total.toLocaleString()}</h3>
               <p className="text-gray-600">Patentes Totales</p>
             </div>
           </div>
@@ -99,7 +112,7 @@ const Admin: React.FC = () => {
               <i className="fas fa-check-circle text-green-600 text-xl"></i>
             </div>
             <div>
-              <h3 className="text-2xl font-bold text-gray-800">1,180</h3>
+              <h3 className="text-2xl font-bold text-gray-800">{stats.active.toLocaleString()}</h3>
               <p className="text-gray-600">Patentes Activas</p>
             </div>
           </div>
@@ -111,7 +124,7 @@ const Admin: React.FC = () => {
               <i className="fas fa-pause-circle text-yellow-600 text-xl"></i>
             </div>
             <div>
-              <h3 className="text-2xl font-bold text-gray-800">68</h3>
+              <h3 className="text-2xl font-bold text-gray-800">{stats.inactive.toLocaleString()}</h3>
               <p className="text-gray-600">Patentes Inactivas</p>
             </div>
           </div>

--- a/frontend/src/services/plateService.ts
+++ b/frontend/src/services/plateService.ts
@@ -33,6 +33,15 @@ export const getAllPlates = async () => {
   }
 };
 
+export const getPlateStats = async () => {
+  try {
+    const response = await api.get('/plates/stats');
+    return response.data;
+  } catch (error: any) {
+    throw new Error(error.response?.data?.error || 'Error fetching plate stats');
+  }
+};
+
 export const registerPlate = async (plateData: any) => {
   try {
     const response = await api.post('/plates', plateData);


### PR DESCRIPTION
## Summary
- expose `/plates/stats` endpoint for total, active, and inactive counts
- display real plate statistics in admin dashboard

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm run build` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run build` (frontend) *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b8db2f8e6083248047e87d9f3b56f2