### PR TITLE
Return all plates regardless of active status

### DIFF
--- a/backend/src/controllers/plateController.ts
+++ b/backend/src/controllers/plateController.ts
@@ -11,14 +11,14 @@ export const getPlates = async (req: Request, res: Response): Promise<void> => {
   try {
     // Obtener placas con paginación
     const plates = await query(
-      `SELECT * FROM plates WHERE is_active = TRUE
+      `SELECT * FROM plates
        ORDER BY created_at DESC LIMIT ? OFFSET ?`,
       [limit, offset]
     );
 
     // Obtener conteo total
     const countResult = await query(
-      'SELECT COUNT(*) as total FROM plates WHERE is_active = TRUE'
+      'SELECT COUNT(*) as total FROM plates'
     );
 
     const total = countResult[0].total;
@@ -58,7 +58,7 @@ export const getPlateStats = async (req: Request, res: Response): Promise<void> 
 export const getPlate = async (req: Request, res: Response): Promise<void> => {
   try {
     const plates = await query(
-      'SELECT * FROM plates WHERE id = ? AND is_active = TRUE',
+      'SELECT * FROM plates WHERE id = ?',
       [req.params.id]
     );
 

--- a/frontend/src/services/plateService.ts
+++ b/frontend/src/services/plateService.ts
@@ -2,7 +2,7 @@ import api from './api';
 
 export const processVerification = async (formData: FormData) => {
   try {
-    const response = await api.post('/recognition/process', formData, {
+    const response = await api.post('recognition/process', formData, {
       headers: {
         'Content-Type': 'multipart/form-data'
       }
@@ -15,7 +15,7 @@ export const processVerification = async (formData: FormData) => {
 
 export const getVerificationHistory = async (page = 1, limit = 10) => {
   try {
-    const response = await api.get('/recognition/history', {
+    const response = await api.get('recognition/history', {
       params: { page, limit }
     });
     return response.data;
@@ -26,7 +26,7 @@ export const getVerificationHistory = async (page = 1, limit = 10) => {
 
 export const getAllPlates = async () => {
   try {
-    const response = await api.get('/plates');
+    const response = await api.get('plates');
     return response.data;
   } catch (error: any) {
     throw new Error(error.response?.data?.error || 'Error fetching plates');
@@ -35,7 +35,7 @@ export const getAllPlates = async () => {
 
 export const getPlateStats = async () => {
   try {
-    const response = await api.get('/plates/stats');
+    const response = await api.get('plates/stats');
     return response.data;
   } catch (error: any) {
     throw new Error(error.response?.data?.error || 'Error fetching plate stats');
@@ -44,7 +44,7 @@ export const getPlateStats = async () => {
 
 export const registerPlate = async (plateData: any) => {
   try {
-    const response = await api.post('/plates', plateData);
+    const response = await api.post('plates', plateData);
     return response.data;
   } catch (error: any) {
     throw new Error(error.response?.data?.error || 'Error registering plate');
@@ -53,7 +53,7 @@ export const registerPlate = async (plateData: any) => {
 
 export const updatePlate = async (id: string, plateData: any) => {
   try {
-    const response = await api.put(`/plates/${id}`, plateData);
+    const response = await api.put(`plates/${id}`, plateData);
     return response.data;
   } catch (error: any) {
     throw new Error(error.response?.data?.error || 'Error updating plate');
@@ -62,7 +62,7 @@ export const updatePlate = async (id: string, plateData: any) => {
 
 export const deletePlate = async (id: string) => {
   try {
-    const response = await api.delete(`/plates/${id}`);
+    const response = await api.delete(`plates/${id}`);
     return response.data;
   } catch (error: any) {
     throw new Error(error.response?.data?.error || 'Error deleting plate');


### PR DESCRIPTION
## Summary
- include inactive plates in list query so frontend can display complete registry
- allow fetching plate details regardless of active state
- use relative plate service endpoints so API base path is honored

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8ead65f2883248f1e594ef3f0ee20