### PR TITLE
Allow CORS requests from Vite's alternate port

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -14,7 +14,7 @@ const port = process.env.PORT || 3001;
 // Middleware
 app.use(
   cors({
-    origin: ['http://localhost:5173'],
+    origin: ['http://localhost:5173', 'http://localhost:5174'],
     credentials: true,
   })
 );


### PR DESCRIPTION
## Summary
- Allow CORS from `http://localhost:5174` alongside the existing 5173 port

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b91417809483249bc77975b6f5f85e